### PR TITLE
Handle getCurrentActivity return null error

### DIFF
--- a/android/src/main/java/cn/jpush/reactnativejpush/JPushModule.java
+++ b/android/src/main/java/cn/jpush/reactnativejpush/JPushModule.java
@@ -220,9 +220,13 @@ public class JPushModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void getRegistrationID(Callback callback) {
-        mContext = getCurrentActivity();
-        String id = JPushInterface.getRegistrationID(mContext);
-        callback.invoke(id);
+        try {
+            mContext = getCurrentActivity();
+            String id = JPushInterface.getRegistrationID(mContext);
+            callback.invoke(id);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     @ReactMethod


### PR DESCRIPTION
修复在某些机型下 getCurrentActivity 为 null 造成的 getRegistrationID crash，例如 https://github.com/jpush/jpush-react-native/issues/196