### PR TITLE
Explicitly set requiresMainQueueSetup

### DIFF
--- a/ios/RCTJPushModule/RCTJPushModule.m
+++ b/ios/RCTJPushModule/RCTJPushModule.m
@@ -227,6 +227,10 @@ RCT_EXPORT_METHOD(getApplicationIconBadge:(RCTResponseSenderBlock)callback) {
   return dispatch_get_main_queue();
 }
 
++ (BOOL)requiresMainQueueSetup {
+    return YES;
+}
+
 - (void)didRegistRemoteNotification:(NSString *)token {
   [self.bridge.eventDispatcher sendAppEventWithName:@"didRegisterToken"
                                                body:token];


### PR DESCRIPTION
Fixes warning on startup on RN 0.49+:

> Module RCTJPushModule requires main queue setup since it overrides `init` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.