### PR TITLE
bugfix: 保持iOS和Android平台下收到同样的自定义消息

### DIFF
--- a/android/src/main/java/cn/jpush/reactnativejpush/JPushModule.java
+++ b/android/src/main/java/cn/jpush/reactnativejpush/JPushModule.java
@@ -162,6 +162,7 @@ public class JPushModule extends ReactContextBaseJavaModule {
                 case RECEIVE_CUSTOM_MESSAGE:
                     WritableMap map = Arguments.createMap();
                     map.putInt("id", mCachedBundle.getInt(JPushInterface.EXTRA_NOTIFICATION_ID));
+                    map.putString("message", mCachedBundle.getString(JPushInterface.EXTRA_MESSAGE));
                     map.putString("content", mCachedBundle.getString(JPushInterface.EXTRA_MESSAGE));
                     map.putString("content_type", mCachedBundle.getString(JPushInterface.EXTRA_CONTENT_TYPE));
                     map.putString("title", mCachedBundle.getString(JPushInterface.EXTRA_TITLE));

--- a/android/src/main/java/cn/jpush/reactnativejpush/JPushModule.java
+++ b/android/src/main/java/cn/jpush/reactnativejpush/JPushModule.java
@@ -162,7 +162,9 @@ public class JPushModule extends ReactContextBaseJavaModule {
                 case RECEIVE_CUSTOM_MESSAGE:
                     WritableMap map = Arguments.createMap();
                     map.putInt("id", mCachedBundle.getInt(JPushInterface.EXTRA_NOTIFICATION_ID));
-                    map.putString("message", mCachedBundle.getString(JPushInterface.EXTRA_MESSAGE));
+                    map.putString("content", mCachedBundle.getString(JPushInterface.EXTRA_MESSAGE));
+                    map.putString("content_type", mCachedBundle.getString(JPushInterface.EXTRA_CONTENT_TYPE));
+                    map.putString("title", mCachedBundle.getString(JPushInterface.EXTRA_TITLE));
                     map.putString("extras", mCachedBundle.getString(JPushInterface.EXTRA_EXTRA));
                     mRAC.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
                             .emit(mEvent, map);
@@ -177,7 +179,7 @@ public class JPushModule extends ReactContextBaseJavaModule {
                             .emit(mEvent, map);
                     break;
             }
-                 
+
             mEvent = null;
             mCachedBundle = null;
         }

--- a/example/App.js
+++ b/example/App.js
@@ -228,7 +228,7 @@ export default class App extends Component {
 
     JPushModule.addReceiveCustomMsgListener(map => {
       this.setState({
-        pushMsg: map.message
+        pushMsg: map.content
       })
       console.log('extras: ' + map.extras)
     })


### PR DESCRIPTION
参考[Push API v3 -
极光文档](https://docs.jiguang.cn/jpush/server/push/rest_api_v3_push/#message)修改Android下接收到的自定义消息的内容

fix #515 