### PR TITLE
For fixing issue in android studio with minSdk

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="cn.jpush.reactnativejpush">
 
-    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="22" />
     <!-- Required 自定义用来收发消息的相关权限 -->
     <permission
         android:name="${applicationId}.permission.JPUSH_MESSAGE"


### PR DESCRIPTION
Use <useSdk /> with minSdk will reported error during gradle sync.

> ERROR: The minSdk version should not be declared in the android manifest file. You can move the version from the manifest to the defaultConfig in the build.gradle file.
Remove minSdkVersion and sync project