### PR TITLE
修复应用在热启动的情况下，点击推送无法触发addNotificationListener的问题

### DIFF
--- a/android/src/main/java/cn/jiguang/plugins/push/JPushModule.java
+++ b/android/src/main/java/cn/jiguang/plugins/push/JPushModule.java
@@ -5,7 +5,6 @@ import android.app.Activity;
 import android.app.Application;
 import android.os.Bundle;
 import android.text.TextUtils;
-import android.util.Log;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
@@ -27,6 +26,7 @@ import cn.jiguang.plugins.push.helper.JPushHelper;
 import cn.jiguang.plugins.push.receiver.JPushBroadcastReceiver;
 import cn.jpush.android.api.BasicPushNotificationBuilder;
 import cn.jpush.android.api.JPushInterface;
+import cn.jpush.android.api.NotificationMessage;
 import cn.jpush.android.data.JPushLocalNotification;
 
 public class JPushModule extends ReactContextBaseJavaModule {
@@ -34,6 +34,8 @@ public class JPushModule extends ReactContextBaseJavaModule {
     public static ReactApplicationContext reactContext;
 
     public static boolean isAppForeground = false;
+
+    public static NotificationMessage notificationMessage = null;
 
     public JPushModule(ReactApplicationContext reactApplicationContext) {
         super(reactContext);
@@ -58,6 +60,11 @@ public class JPushModule extends ReactContextBaseJavaModule {
             WritableMap writableMap = JPushHelper.convertNotificationBundleToMap(JConstants.NOTIFICATION_OPENED, JPushBroadcastReceiver.NOTIFICATION_BUNDLE);
             JPushHelper.sendEvent(JConstants.NOTIFICATION_EVENT, writableMap);
             JPushBroadcastReceiver.NOTIFICATION_BUNDLE = null;
+        }
+        if (JPushModule.notificationMessage != null) {
+            WritableMap writableMap = JPushHelper.convertNotificationToMap(JConstants.NOTIFICATION_OPENED, notificationMessage);
+            JPushHelper.sendEvent(JConstants.NOTIFICATION_EVENT, writableMap);
+            JPushModule.notificationMessage = null;
         }
     }
 

--- a/android/src/main/java/cn/jiguang/plugins/push/receiver/JPushModuleReceiver.java
+++ b/android/src/main/java/cn/jiguang/plugins/push/receiver/JPushModuleReceiver.java
@@ -40,6 +40,7 @@ public class JPushModuleReceiver extends JPushMessageReceiver {
     JLogger.d("onNotifyMessageOpened:" + notificationMessage.toString());
     if (JPushModule.reactContext != null) {
       if (!JPushModule.isAppForeground) JPushHelper.launchApp(context);
+      JPushModule.notificationMessage = notificationMessage;
       WritableMap writableMap = JPushHelper.convertNotificationToMap(JConstants.NOTIFICATION_OPENED, notificationMessage);
       JPushHelper.sendEvent(JConstants.NOTIFICATION_EVENT, writableMap);
     } else {


### PR DESCRIPTION
原先在以下操作下存在addNotificationListener无法触发的问题

1. 打开进入应用
2. 按安卓的返回键或者手势进行退出【非任务管理，结束进程】
3. 发送推送通知
4. 点击推送通知，打开应用并没有触发addNotificationListener

原因：
https://github.com/jpush/jpush-react-native/blob/dcb48c1cba608e9cddfa69f08f67910adc8c8cf2/android/src/main/java/cn/jiguang/plugins/push/receiver/JPushModuleReceiver.java#L39
接收到通知点击后，启动app，并发送事件。但是上述情况是退出app，发送事件时，js端还未添加监听事件。