### PR TITLE
升级 JPush SDK 6.2.0 并新增通道订阅接口

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,9 @@
+.claude/
+.cursor/
+.idea/
+.github/
 example/
 cursor.md
-.cursor/
+*.tgz
+**/xcuserdata/
+**/*.xcuserstate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.2.8 (2026-07-28)
+
+- Android：JPush SDK 6.1.0 → 6.2.0，配套 JCore SDK 5.5.0。
+- iOS：JPush SDK 6.1.0 → 6.2.0，配套 JCore SDK 5.5.0。
+- `jcore-react-native` 最低版本调整为 2.3.7。
+- Android：新增 `requestSubscribeChannel(channelIds)` JS API，结果通过 `addCommandEventListener` 的 `command === 2012` 事件返回。
+
 ## 3.2.7 (2026-05-09)
 
 Upgrade JPush Android SDK to 6.1.0 and iOS SDK to 6.1.0; add setBackgroundEnable (Android) and getKeepLongConnInBackground (Android Only)

--- a/JPushRN.podspec
+++ b/JPushRN.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
   s.frameworks      = 'UIKit','CFNetwork','CoreFoundation','CoreTelephony','SystemConfiguration','CoreGraphics','Foundation','Security'
   s.weak_frameworks = 'UserNotifications'
   s.libraries       = 'z','resolv'
-  s.dependency 'JPush','6.1.0'
+  s.dependency 'JPush','6.2.0'
   s.dependency 'React'
 end

--- a/README.md
+++ b/README.md
@@ -139,6 +139,42 @@ pod install
 
 详见：[index.js](https://github.com/jpush/jpush-react-native/blob/master/index.js)
 
+### 4.1 Android 请求订阅厂商通知通道
+
+JPush Android SDK 6.2.0 起支持请求订阅厂商通知通道。当前仅支持已集成并注册小米通道的小米设备，且调用时应用需处于前台、屏幕已点亮。
+
+```javascript
+const commandListener = result => {
+  if (result.command === 2012) {
+    const channelResults = result.openChannelResult
+      ? JSON.parse(result.openChannelResult)
+      : [];
+    console.log(result.commandResult, result.platform, channelResults);
+  }
+};
+
+JPush.addCommandEventListener(commandListener);
+JPush.requestSubscribeChannel(["YOUR_XIAOMI_CHANNEL_ID"]);
+
+// 页面销毁时移除监听
+JPush.removeListener(commandListener);
+```
+
+- `channelIds`：在小米后台审核通过的订阅类 channel ID 数组，单次最多处理 3 个。
+- `commandResult`：请求结果码；`0` 表示正常拉起弹窗并返回用户操作结果。
+- `openChannelResult`：各 channel 处理结果的 JSON 数组字符串，例如 `[{"channelId":"xxx","code":100}]`。
+- `platform`：厂商平台，当前小米为 `1`。
+- 回调命令固定为 `command === 2012`。弹窗 30 秒内最多拉起一次，同一 channel 每月最多拉起两次。
+
+`commandResult` 常见结果码：
+
+- `0`：正常拉起弹窗并返回用户操作结果。
+- `-100`：当前版本不支持；`-200`：鉴权失败；`-300`：应用不在前台或屏幕未点亮。
+- `-500`：触发频控；`-700`：用户取消；`-800`：应用没有通知权限。
+
+`openChannelResult` 中每个 channel 的 `code`：`100` 成功，`-100` 失败，
+`-200` 用户拒绝，`-300` 已存在且开启，`-400` 已存在但关闭，`-500` channel ID 非法。
+
 ## 5.  其他
 
 * 集成前务必将example工程跑通
@@ -146,4 +182,3 @@ pod install
 * 上报问题还麻烦先调用JPush.setLoggerEnable(true}，拿到debug日志
 
  
-

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,5 +21,5 @@ android {
 dependencies {
     // implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.facebook.react:react-native:+'
-    implementation 'cn.jiguang.sdk:jpush:6.1.0'  
+    implementation 'cn.jiguang.sdk:jpush:6.2.0'
 }

--- a/android/src/main/java/cn/jiguang/plugins/push/JPushModule.java
+++ b/android/src/main/java/cn/jiguang/plugins/push/JPushModule.java
@@ -22,6 +22,7 @@ import com.facebook.react.bridge.WritableMap;
 
 import org.json.JSONObject;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
@@ -77,6 +78,26 @@ public class JPushModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void resumePush() {
         JPushInterface.resumePush(reactContext);
+    }
+
+    @ReactMethod
+    public void requestSubscribeChannel(ReadableArray channelIds) {
+        if (channelIds == null || channelIds.size() == 0) {
+            JLogger.w(JConstants.PARAMS_NULL);
+            return;
+        }
+        ArrayList<String> channels = new ArrayList<String>();
+        for (int i = 0; i < channelIds.size(); i++) {
+            String channelId = channelIds.getString(i);
+            if (!TextUtils.isEmpty(channelId)) {
+                channels.add(channelId);
+            }
+        }
+        if (channels.isEmpty()) {
+            JLogger.w(JConstants.PARAMS_ILLEGAL);
+            return;
+        }
+        JPushInterface.requestSubscribeChannel(reactContext, channels);
     }
 
     @ReactMethod

--- a/android/src/main/java/cn/jiguang/plugins/push/common/JConstants.java
+++ b/android/src/main/java/cn/jiguang/plugins/push/common/JConstants.java
@@ -45,6 +45,11 @@ public class JConstants {
     public static final String COMMAND_EXTRA = "commandExtra";
     public static final String COMMAND_RESULT = "commandResult";
     public static final String COMMAND_MESSAGE = "commandMessage";
+    public static final String OPEN_CHANNEL_RESULT = "openChannelResult";
+    public static final String PLATFORM = "platform";
+    public static final String OPEN_CHANNEL_RESULT_EXTRA = "open_channel_result";
+    public static final String PLATFORM_EXTRA = "jg_platform";
+    public static final int REQUEST_SUBSCRIBE_CHANNEL_COMMAND = 2012;
     //地理围栏
     public static final String GEO_FENCE_ID = "geoFenceID";
     public static final String GEO_FENCE_INTERVAL = "geoFenceInterval";

--- a/android/src/main/java/cn/jiguang/plugins/push/receiver/JPushModuleReceiver.java
+++ b/android/src/main/java/cn/jiguang/plugins/push/receiver/JPushModuleReceiver.java
@@ -116,6 +116,14 @@ public class JPushModuleReceiver extends JPushMessageReceiver {
     writableMap.putString(JConstants.COMMAND_EXTRA, message.extra != null ? message.extra.toString() : "");
     writableMap.putString(JConstants.COMMAND_MESSAGE, message.msg);
     writableMap.putInt(JConstants.COMMAND_RESULT, message.errorCode);
+    if (message.cmd == JConstants.REQUEST_SUBSCRIBE_CHANNEL_COMMAND && message.extra != null) {
+      writableMap.putString(
+          JConstants.OPEN_CHANNEL_RESULT,
+          message.extra.getString(JConstants.OPEN_CHANNEL_RESULT_EXTRA, ""));
+      writableMap.putInt(
+          JConstants.PLATFORM,
+          message.extra.getInt(JConstants.PLATFORM_EXTRA, 0));
+    }
     JPushHelper.sendEvent(JConstants.COMMAND_EVENT, writableMap);
   }
 

--- a/example/App.js
+++ b/example/App.js
@@ -97,6 +97,11 @@ export default class App extends React.Component {
     console.log("mobileNumberListener:" + JSON.stringify(result))
   };
     JPush.addMobileNumberListener(this.mobileNumberListener);
+    //Command 事件回调，requestSubscribeChannel 的结果 command 为 2012
+    this.commandListener = result => {
+    console.log("commandListener:" + JSON.stringify(result))
+  };
+    JPush.addCommandEventListener(this.commandListener);
   }
 
   render() {
@@ -113,6 +118,9 @@ export default class App extends React.Component {
 
     <Button title="设置用户属性"
     onPress={() => JPush.setProperties({sequence: 1, pros:{2:'b'}})}/>
+
+    <Button title="requestSubscribeChannel"
+    onPress={() => JPush.requestSubscribeChannel(["155012"])}/>
     {/*<Button title="addTags"
                                   onPress={() => JPush.addTags({sequence: 1, tags: ["1", "2", "3"]})}/>
 
@@ -166,6 +174,3 @@ export default class App extends React.Component {
   }
 
 }
-
-
-

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -68,6 +68,12 @@ def enableProguardInReleaseBuilds = false
  * this variant is about 6MiB larger per architecture than default.
  */
 def jscFlavor = 'org.webkit:android-jsc:+'
+// 厂商通道测试参数通过 Gradle -P 注入，避免测试凭据写入源码。
+def testApplicationId = project.findProperty("jpushTestApplicationId") ?: "cn.allpublic"
+def testJPushAppKey = project.findProperty("jpushTestAppKey") ?: "32f266ea08c3b3d7a059b378"
+def testXiaomiAppId = project.findProperty("xiaomiAppId") ?: ""
+def testXiaomiAppKey = project.findProperty("xiaomiAppKey") ?: ""
+def enableXiaomiChannel = !testXiaomiAppId.isEmpty() && !testXiaomiAppKey.isEmpty()
 
 android {
     ndkVersion rootProject.ext.ndkVersion
@@ -76,15 +82,17 @@ android {
 
     namespace "com.example"
     defaultConfig {
-        applicationId "cn.allpublic"
+        applicationId testApplicationId
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
 
         manifestPlaceholders = [
-                JPUSH_APPKEY: "32f266ea08c3b3d7a059b378",         //在此替换你的APPKey
-                JPUSH_CHANNEL: "test"        //在此替换你的channel
+                JPUSH_APPKEY: testJPushAppKey, //在此替换你的APPKey
+                JPUSH_CHANNEL: "test",       //在此替换你的channel
+                XIAOMI_APPID: testXiaomiAppId,
+                XIAOMI_APPKEY: testXiaomiAppKey
         ]
     }
     signingConfigs {
@@ -112,6 +120,9 @@ android {
 dependencies {
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
+    if (enableXiaomiChannel) {
+        implementation("cn.jiguang.sdk.plugin:xiaomi:6.2.0")
+    }
 
     if (hermesEnabled.toBoolean()) {
         implementation("com.facebook.react:hermes-android")

--- a/example/ios-swift/AppDelegate.swift
+++ b/example/ios-swift/AppDelegate.swift
@@ -96,6 +96,7 @@ extension AppDelegate:JPUSHRegisterDelegate {
     if (response.notification.request.trigger?.isKind(of: UNPushNotificationTrigger.self) == true) {
       // 注意调用
       JPUSHService.handleRemoteNotification(userInfo)
+      RCTJPushEventQueue.sharedInstance()._notificationQueue?.insert(userInfo as NSDictionary, at: 0)
       NotificationCenter.default.post(name: NSNotification.Name(J_APNS_NOTIFICATION_OPENED_EVENT), object: userInfo)
       print("点击远程通知:\(userInfo)")
       

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -7,9 +7,14 @@ PODS:
   - hermes-engine (0.74.1):
     - hermes-engine/Pre-built (= 0.74.1)
   - hermes-engine/Pre-built (0.74.1)
-  - JCoreRN (2.2.8):
+  - JCore (5.5.0)
+  - JCoreRN (2.3.7):
+    - JCore (= 5.5.0)
     - React
-  - JPushRN (3.1.5):
+  - JPush (6.2.0):
+    - JCore (> 5.1.1)
+  - JPushRN (3.2.8):
+    - JPush (= 6.2.0)
     - React
   - RCT-Folly (2024.01.01.00):
     - boost
@@ -1233,6 +1238,8 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
+    - JCore
+    - JPush
     - SocketRocket
 
 EXTERNAL SOURCES:
@@ -1357,8 +1364,10 @@ SPEC CHECKSUMS:
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   hermes-engine: 16b8530de1b383cdada1476cf52d1b52f0692cbc
-  JCoreRN: 0dbe7981735de54c772a2f3ea275c53421649981
-  JPushRN: e4b15bc4e339d2bf947930d4505546a207d0e766
+  JCore: 38810b2235642507e9632ceb5bb66805042909bb
+  JCoreRN: e43ceff2d36551a120af05d2b9508bd7058ff9f4
+  JPush: eb729308f4d3c579840d4ba41a67065e8c491ada
+  JPushRN: 60386a9b74ee49c1e647d48e3c6be3497e1dc71f
   RCT-Folly: 5dc73daec3476616d19e8a53f0156176f7b55461
   RCTDeprecation: efb313d8126259e9294dc4ee0002f44a6f676aba
   RCTRequired: f49ea29cece52aee20db633ae7edc4b271435562
@@ -1411,4 +1420,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 71a689932e49f453bd6454dd189b45915dda66a0
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.14.3

--- a/example/package.json
+++ b/example/package.json
@@ -10,8 +10,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "jcore-react-native": "^2.3.0",
-    "jpush-react-native": "^3.2.2",
+    "jcore-react-native": "2.3.7",
+    "jpush-react-native": "3.2.8",
     "react": "18.2.0",
     "react-native": "0.74.1"
   },

--- a/index.d.ts
+++ b/index.d.ts
@@ -401,6 +401,17 @@ export default class JPush {
                  * 命令的执行结果（例如：0 表示成功，其他值表示错误码）
                  */
                 commandResult: number;
+
+                /**
+                 * 订阅通道结果的 JSON 数组字符串，仅 command 为 2012 时返回。
+                 * 例如：[{"channelId":"xxx","code":100}]
+                 */
+                openChannelResult?: string;
+
+                /**
+                 * 厂商平台，仅 command 为 2012 时返回；1 表示小米。
+                 */
+                platform?: number;
             }>
         ): void;
   /**
@@ -464,6 +475,16 @@ export default class JPush {
    * @platform Android
    */
   static resumePush(): void;
+
+  /**
+   * 请求订阅厂商通知通道。当前仅支持已集成小米通道的 Android 小米设备。
+   *
+   * 单次最多处理 3 个在小米后台审核通过的订阅类 channel ID。
+   * 结果通过 addCommandEventListener 返回，其中 command 为 2012。
+   *
+   * @platform Android
+   */
+  static requestSubscribeChannel(channelIds: string[]): void;
 
   /**
    * 用来检查 Push Service 是否已经被停止

--- a/index.js
+++ b/index.js
@@ -650,6 +650,19 @@ export default class JPush {
     }
 
     /*
+    * 请求订阅厂商通知通道。当前仅支持已集成小米通道的 Android 小米设备。
+    *
+    * @param channelIds = StringArray，单次最多处理 3 个小米订阅类 channel ID
+    *
+    * 结果通过 addCommandEventListener 回调，command 为 2012。
+    * */
+    static requestSubscribeChannel(channelIds) {
+        if (Platform.OS == "android") {
+            JPushModule.requestSubscribeChannel(channelIds)
+        }
+    }
+
+    /*
     * 用来检查 Push Service 是否已经被停止
     * */
     static isPushStopped(callback) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "index.d.ts",
   "license": "ISC",
   "author": "wicked.tc130",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "repository": {
     "type": "git",
     "url": "https://github.com/jpush/jpush-react-native"
@@ -16,7 +16,7 @@
     "JPush"
   ],
   "peerDependencies": {
-    "jcore-react-native": ">= 1.9.3",
+    "jcore-react-native": ">= 2.3.7",
     "react-native": ">= 0.50"
   }
 }


### PR DESCRIPTION
## 变更内容

- JPush Android/iOS SDK 从 6.1.0 升级到 6.2.0
- 插件版本升级到 3.2.8，并要求 jcore-react-native >= 2.3.7
- Android 新增 requestSubscribeChannel(channelIds) JS/TypeScript/Native 接口
- 复用 CommandEvent 返回 command=2012、openChannelResult 和 platform
- example 增加 Channel ID 155012 调用入口及小米通道参数化测试配置
- Swift 示例补充冷启动通知队列写入，修复杀死 App 后点击通知不回调
- 同步 README、CHANGELOG、Podfile.lock 和 npm 发布排除规则

## 依赖 PR

- jcore-react-native 2.3.7：https://github.com/jpush/jcore-react-native/pull/81

## 验证结果

- Android JPush 6.2.0/JCore 5.5.0 依赖解析、debug/release 构建、安装和启动通过
- iOS JPush 6.2.0/JCore 5.5.0 Pod 解析与 no-codesign 构建通过
- npm pack 内容检查和 git diff --check 通过
- Mi 10 已完成小米 token 注册及 command=2012 的 Native→JS 回调验证
- 无小米 Gradle 参数时不引入小米厂商依赖

## 已知限制

- Mi 10 返回 commandResult=-100，未验证成功弹窗、用户接受/拒绝及非空 openChannelResult
- JPush 6.2.0 与小米厂商包存在非阻塞 D8 stack map warning
- 未执行双端完整推送业务回归及 iOS 真机签名验证
- example 既有 lint/Jest 配置问题不属于本次变更